### PR TITLE
Fix Github Workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,46 +6,103 @@ on:
       version:
         description: 'Go version to build ("1.17")'
         required: true
+      prerelease:
+        description: 'Is this a pre-release?'
+        required: true
+        default: 'false'
 
 jobs:
   build:
     strategy:
       matrix:
         include:
-          - builder: ubuntu-latest
-            goos: linux
-            goarch: amd64
-          - builder: macos-latest
-            goos: darwin
-            goarch: amd64
           - builder: macos-latest
             goos: darwin
             goarch: arm64
+          - builder: macos-latest
+            goos: darwin
+            goarch: amd64
+          - builder: ubuntu-latest
+            goos: linux
+            goarch: amd64
           - builder: windows-latest
             goos: windows
             goarch: amd64
 
     runs-on: ${{ matrix.builder }}
+    outputs:
+      built_version: ${{ steps.encore_go_version.outputs.version }}
     steps:
       - name: Check out repo
         uses: actions/checkout@v2
+        with:
+          fetch-depth: 0   # We need the full history for the Go submodule
+          submodules: true # Checkout the Go submodule
 
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
           go-version: 1.17
+
       - name: 'Create patched runtime'
         run: bash ./apply_patch.bash "${{ github.event.inputs.version }}"
-        env:
-          GO111MODULE: "on"
+
       - name: Build
         run: go run . -dst=dist -goos=${{ matrix.goos }} -goarch=${{ matrix.goarch }}
         env:
           GO111MODULE: "on"
+
+      # This step gets the exact version of Go we're releasing (including minor), so if we give the input as `1.17` this might return `encore-go1.17.5`.
+      - name: 'Read the version of Go we built'
+        id: encore_go_version
+        run: echo "::set-output name=version::$(go run . --read-built-version)"
+
       - name: 'Tar artifacts'
-        run: tar -czvf encore-go-${{ github.event.inputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz -C dist/${{ matrix.goos }}_${{ matrix.goarch }} .
-      - name: Publish artifact
+        run: tar -czvf ${{ steps.encore_go_version.outputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz -C dist/${{ matrix.goos }}_${{ matrix.goarch }} .
+
+      - name: 'Upload build artifact'
         uses: actions/upload-artifact@v2
         with:
-          name: encore-go-${{ github.event.inputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}
-          path: encore-go-${{ github.event.inputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
+          name: ${{ steps.encore_go_version.outputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}
+          path: ${{ steps.encore_go_version.outputs.version }}-${{ matrix.goos }}_${{ matrix.goarch }}.tar.gz
+  release:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: 'Download artifacts from build steps'
+        uses: actions/download-artifact@v2
+
+      - name: 'Convert windows artifact to zip'
+        run: |
+          cd ${{needs.build.outputs.built_version}}-windows_amd64
+          tar -xzf ${{needs.build.outputs.built_version}}-windows_amd64.tar.gz
+          zip -r ${{needs.build.outputs.built_version}}-windows_amd64.zip encore-go
+
+      - name: 'Move, rename and create checksums for the artifacts'
+        run: |
+          mkdir output
+          mv ${{needs.build.outputs.built_version}}-linux_amd64/${{needs.build.outputs.built_version}}-linux_amd64.tar.gz output/Linux_x86-64.tar.gz
+          mv ${{needs.build.outputs.built_version}}-darwin_amd64/${{needs.build.outputs.built_version}}-darwin_amd64.tar.gz output/macOS_x86-64.tar.gz
+          mv ${{needs.build.outputs.built_version}}-darwin_arm64/${{needs.build.outputs.built_version}}-darwin_arm64.tar.gz output/macOS_arm64.tar.gz
+          mv ${{needs.build.outputs.built_version}}-windows_amd64/${{needs.build.outputs.built_version}}-windows_amd64.tar.gz output/Windows_x86-64.tar.gz
+          mv ${{needs.build.outputs.built_version}}-windows_amd64/${{needs.build.outputs.built_version}}-windows_amd64.zip output/Windows_x86-64.zip
+          cd output
+          sha256sum * > checksums.txt
+          ls -R .
+          mv * ../
+          cd ..
+          cat checksums.txt
+
+      - name: 'Publish release'
+        uses: DomBlack/github-release@2.0
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag: ${{ needs.build.outputs.built_version }}
+          name: ${{ needs.build.outputs.built_version }}
+          body: >
+            This release is the compiled version of ${{ needs.build.outputs.built_version }}
+          draft: false
+          allow_override: true
+          prerelease: ${{ github.event.inputs.prerelease }}
+          gzip: false
+          files: Linux_x86-64.tar.gz Windows_x86-64.tar.gz Windows_x86-64.zip macOS_arm64.tar.gz macOS_x86-64.tar.gz checksums.txt

--- a/apply_patch.bash
+++ b/apply_patch.bash
@@ -35,7 +35,7 @@ pushd "$(dirname -- "$0")/go" > /dev/null
 
 # Checkout an updated clean copy of the Go runtime from the $RELEASE_BRANCH
 echo "♻️  Checking out a clean copy of the Go runtime from $RELEASE_BRANCH..."
-  _ git fetch
+  _ git fetch origin "$RELEASE_BRANCH"
 
   _ git checkout -f "$RELEASE_BRANCH"         # Checkout the branch to track it
   _ git reset --hard origin/"$RELEASE_BRANCH" # Reset against the current head of that branch (ignoring any local commits)

--- a/main.go
+++ b/main.go
@@ -2,8 +2,11 @@ package main
 
 import (
 	"flag"
+	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
+	"regexp"
 
 	"go.encore.dev/go/builder"
 )
@@ -12,7 +15,15 @@ func main() {
 	goos := flag.String("goos", "", "GOOS")
 	goarch := flag.String("goarch", "", "GOARCH")
 	dst := flag.String("dst", "dist", "build destination")
+	readVersion := flag.Bool("read-built-version", false, "If set we'll simply parse go/VERSION.cache and return the Go verison")
 	flag.Parse()
+
+	if *readVersion {
+		readBuiltVersion()
+
+		return
+	}
+
 	if *goos == "" || *goarch == "" || *dst == "" {
 		log.Fatalf("missing -dst %q, -goos %q, or -goarch %q", *dst, *goos, *goarch)
 	}
@@ -25,4 +36,25 @@ func main() {
 	if err := builder.BuildEncoreGo(*goos, *goarch, root, *dst); err != nil {
 		log.Fatalln(err)
 	}
+}
+
+func readBuiltVersion() {
+	bytes, err := ioutil.ReadFile("go/VERSION.cache")
+	if err != nil {
+		log.Fatalf("Unable to read built version: %+v", err)
+	}
+
+	str := string(bytes)
+
+	re, err := regexp.Compile("(encore-go[^ ]+)")
+	if err != nil {
+		log.Fatalf("Unable to compile regex: %+v", err)
+	}
+
+	version := re.FindString(str)
+	if version == "" {
+		log.Fatalf("Unable to extract version from `go/VERSION.cache` read: %s", str)
+	}
+
+	fmt.Println(version)
 }

--- a/patches/net_patch.diff
+++ b/patches/net_patch.diff
@@ -1,3 +1,10 @@
+Encore Networking Patch
+=======================
+
+This patch modifies the standard libraries roundTrip function on the HTTP interface, such that Encore's
+`encoreBeginRoundTrip` and `encoreFinishRoundTrip` are called. These calls are routed into Encore runtime and allows us
+instrument the call.
+
 diff --git a/src/net/http/transport.go b/src/net/http/transport.go
 index 0aa48273dd..bf53cad76c 100644
 --- a/src/net/http/transport.go
@@ -22,11 +29,3 @@ index 0aa48273dd..bf53cad76c 100644
  	trace := httptrace.ContextClientTrace(ctx)
 
  	if req.URL == nil {
-@@ -512,6 +520,7 @@ func (t *Transport) roundTrip(req *Request) (*Response, error) {
- 		req.closeBody()
- 		return nil, errors.New("http: nil Request.Header")
- 	}
-+
- 	scheme := req.URL.Scheme
- 	isHTTP := scheme == "http" || scheme == "https"
- 	if isHTTP {

--- a/patches/runtime_patch.diff
+++ b/patches/runtime_patch.diff
@@ -1,3 +1,9 @@
+Encore Runtime Patch
+=======================
+
+This patch modifies the Go runtime to add Encore specific tracking data to the Go Routines `g` struct and Trace the
+the and finish of a Go Routine executed due to a request made to your Encore app.
+
 diff --git a/src/runtime/proc.go b/src/runtime/proc.go
 index 73a789c189..846b9d88fb 100644
 --- a/src/runtime/proc.go

--- a/patches/version_patch.diff
+++ b/patches/version_patch.diff
@@ -1,3 +1,14 @@
+Encore Version Patch
+=======================
+
+This patch modifies the Go build tools (those which build Go itself) to add a "encore" prefix to the version tag, this
+allows us to identify if the Go runtime being used is an Encore patched runtime or it is a standard Go runtime.
+
+It changes the output of `go version` from:
+    `go version go1.17.6 darwin/arm64`
+to:
+    `go version encore-go1.17.6 darwin/arm64`
+
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
 index d37c3f83ef..ea7f17eaa8 100644
 --- a/src/cmd/dist/build.go


### PR DESCRIPTION
This PR fixes the Github workflows since the refactor of this project. The updated workflows now also creates Github releases. For example [this call to the workflow](https://github.com/encoredev/go/actions/runs/1747206709) resulted in [this release](https://github.com/encoredev/go/releases/tag/encore-go1.17.6). It was given the version parameter of `1.17` and it downloaded the latest Go 1.17.x release; patched it; and released it on this repo.

This PR also adds more descriptions to the patch files to explain what each patch file is doing