### PR TITLE
Allow Encore runtime to track tests.

### DIFF
--- a/overlay/src/testing/encore_app.go
+++ b/overlay/src/testing/encore_app.go
@@ -1,0 +1,22 @@
+//go:build encore
+// +build encore
+
+package testing
+
+import _ "unsafe"
+
+// encoreTestStart is called when a test starts running. This allows Encore's testing framework to
+// isolate behaviour between different tests on global state. It is linked to the Encore runtime via go:linkname.
+func encoreTestStart(t *T)
+
+// encoreTestEnd is called when a test ends. This allows Encore's testing framework to clear down any state from the test
+// and to perform any assertions on that state that it needs to. It is linked to the Encore runtime via go:linkname.
+func encoreTestEnd(t *T)
+
+// encoreTestPaused is called when a test is paused. This allows Encore's testing framework to
+// isolate behaviour between different tests on global state. It is linked to the Encore runtime via go:linkname.
+func encoreTestPaused(t *T)
+
+// encoreTestResumed is called when a test is resumed after being paused. This allows Encore's testing framework to clear down any state from the test
+// and to perform any assertions on that state that it needs to. It is linked to the Encore runtime via go:linkname.
+func encoreTestResumed(t *T)

--- a/overlay/src/testing/encore_app.go
+++ b/overlay/src/testing/encore_app.go
@@ -5,18 +5,18 @@ package testing
 
 import _ "unsafe"
 
-// encoreTestStart is called when a test starts running. This allows Encore's testing framework to
-// isolate behaviour between different tests on global state. It is linked to the Encore runtime via go:linkname.
-func encoreTestStart(t *T)
+// encoreStartTest is called when a test starts running. This allows Encore's testing framework to
+// isolate behavior between different tests on global state. It is linked to the Encore runtime via go:linkname.
+func encoreStartTest(t *T)
 
-// encoreTestEnd is called when a test ends. This allows Encore's testing framework to clear down any state from the test
+// encoreEndTest is called when a test ends. This allows Encore's testing framework to clear down any state from the test
 // and to perform any assertions on that state that it needs to. It is linked to the Encore runtime via go:linkname.
-func encoreTestEnd(t *T)
+func encoreEndTest(t *T)
 
-// encoreTestPaused is called when a test is paused. This allows Encore's testing framework to
-// isolate behaviour between different tests on global state. It is linked to the Encore runtime via go:linkname.
-func encoreTestPaused(t *T)
+// encorePauseTest is called when a test is paused. This allows Encore's testing framework to
+// isolate behavior between different tests on global state. It is linked to the Encore runtime via go:linkname.
+func encorePauseTest(t *T)
 
-// encoreTestResumed is called when a test is resumed after being paused. This allows Encore's testing framework to clear down any state from the test
+// encoreResumeTest is called when a test is resumed after being paused. This allows Encore's testing framework to clear down any state from the test
 // and to perform any assertions on that state that it needs to. It is linked to the Encore runtime via go:linkname.
-func encoreTestResumed(t *T)
+func encoreResumeTest(t *T)

--- a/overlay/src/testing/encore_noapp.go
+++ b/overlay/src/testing/encore_noapp.go
@@ -3,22 +3,22 @@
 
 package testing
 
-// encoreTestStart is called when a test starts running. This allows Encore's testing framework to
-// isolate behaviour between different tests on global state.
+// encoreStartTest is called when a test starts running. This allows Encore's testing framework to
+// isolate behavior between different tests on global state.
 //
 // This implementation is simply a no-op as it's used when the tests are not being run against an Encore application
-func encoreTestStart(t *T) {}
+func encoreStartTest(t *T) {}
 
-// encoreTestEnd is called when a test ends. This allows Encore's testing framework to clear down any state from the test
+// encoreEndTest is called when a test ends. This allows Encore's testing framework to clear down any state from the test
 // and to perform any assertions on that state that it needs to. It is linked to the Encore runtime via go:linkname.
 //
 // This implementation is simply a no-op as it's used when the tests are not being run against an Encore application
-func encoreTestEnd(t *T) {}
+func encoreEndTest(t *T) {}
 
-// encoreTestPaused is called when a test is paused. This allows Encore's testing framework to
-// isolate behaviour between different tests on global state. It is linked to the Encore runtime via go:linkname.
-func encoreTestPaused(t *T) {}
+// encorePauseTest is called when a test is paused. This allows Encore's testing framework to
+// isolate behavior between different tests on global state. It is linked to the Encore runtime via go:linkname.
+func encorePauseTest(t *T) {}
 
-// encoreTestResumed is called when a test is resumed after being paused. This allows Encore's testing framework to clear down any state from the test
+// encoreResumeTest is called when a test is resumed after being paused. This allows Encore's testing framework to clear down any state from the test
 // and to perform any assertions on that state that it needs to. It is linked to the Encore runtime via go:linkname.
-func encoreTestResumed(t *T) {}
+func encoreResumeTest(t *T) {}

--- a/overlay/src/testing/encore_noapp.go
+++ b/overlay/src/testing/encore_noapp.go
@@ -1,0 +1,24 @@
+//go:build !encore
+// +build !encore
+
+package testing
+
+// encoreTestStart is called when a test starts running. This allows Encore's testing framework to
+// isolate behaviour between different tests on global state.
+//
+// This implementation is simply a no-op as it's used when the tests are not being run against an Encore application
+func encoreTestStart(t *T) {}
+
+// encoreTestEnd is called when a test ends. This allows Encore's testing framework to clear down any state from the test
+// and to perform any assertions on that state that it needs to. It is linked to the Encore runtime via go:linkname.
+//
+// This implementation is simply a no-op as it's used when the tests are not being run against an Encore application
+func encoreTestEnd(t *T) {}
+
+// encoreTestPaused is called when a test is paused. This allows Encore's testing framework to
+// isolate behaviour between different tests on global state. It is linked to the Encore runtime via go:linkname.
+func encoreTestPaused(t *T) {}
+
+// encoreTestResumed is called when a test is resumed after being paused. This allows Encore's testing framework to clear down any state from the test
+// and to perform any assertions on that state that it needs to. It is linked to the Encore runtime via go:linkname.
+func encoreTestResumed(t *T) {}

--- a/patches/testing_patch.diff
+++ b/patches/testing_patch.diff
@@ -13,13 +13,13 @@ index df4dfe4490..10052e09b6 100644
  		t.chatty.Updatef(t.name, "=== PAUSE %s\n", t.name)
  	}
 
-+	encoreTestPaused(t)
++	encorePauseTest(t)
 +
  	t.signal <- true   // Release calling test.
  	<-t.parent.barrier // Wait for the parent test to complete.
  	t.context.waitParallel()
 
-+	encoreTestResumed(t)
++	encoreResumeTest(t)
 +
  	if t.chatty != nil {
  		t.chatty.Updatef(t.name, "=== CONT  %s\n", t.name)
@@ -28,14 +28,14 @@ index df4dfe4490..10052e09b6 100644
 
  func tRunner(t *T, fn func(t *T)) {
  	t.runner = callerName(0)
-+	encoreTestStart(t)
++	encoreStartTest(t)
 
  	// When this goroutine is done, either because fn(t)
  	// returned normally or because a test failure triggered
  	// a call to runtime.Goexit, record the duration and send
  	// a signal saying that the test is done.
  	defer func() {
-+		encoreTestEnd(t)
++		encoreEndTest(t)
  		if t.Failed() {
  			atomic.AddUint32(&numFailed, 1)
  		}

--- a/patches/testing_patch.diff
+++ b/patches/testing_patch.diff
@@ -1,0 +1,41 @@
+Testing Patch
+====================
+
+Encore's framework creates resources as package level variables. This makes running tests in parallel harder, as each
+test runs against global state. This patch introduces a per test level callback which allows the runtime to track the
+test and not have state between tests interfere with each other.
+
+diff --git a/src/testing/testing.go b/src/testing/testing.go
+index df4dfe4490..10052e09b6 100644
+--- a/src/testing/testing.go
++++ b/src/testing/testing.go
+@@ -1260,10 +1260,14 @@ func (t *T) Parallel() {
+ 		t.chatty.Updatef(t.name, "=== PAUSE %s\n", t.name)
+ 	}
+
++	encoreTestPaused(t)
++
+ 	t.signal <- true   // Release calling test.
+ 	<-t.parent.barrier // Wait for the parent test to complete.
+ 	t.context.waitParallel()
+
++	encoreTestResumed(t)
++
+ 	if t.chatty != nil {
+ 		t.chatty.Updatef(t.name, "=== CONT  %s\n", t.name)
+ 	}
+@@ -1298,12 +1302,14 @@ var errNilPanicOrGoexit = errors.New("test executed panic(nil) or runtime.Goexit
+
+ func tRunner(t *T, fn func(t *T)) {
+ 	t.runner = callerName(0)
++	encoreTestStart(t)
+
+ 	// When this goroutine is done, either because fn(t)
+ 	// returned normally or because a test failure triggered
+ 	// a call to runtime.Goexit, record the duration and send
+ 	// a signal saying that the test is done.
+ 	defer func() {
++		encoreTestEnd(t)
+ 		if t.Failed() {
+ 			atomic.AddUint32(&numFailed, 1)
+ 		}


### PR DESCRIPTION
This addition to the Encore Go fork allows the Encore runtime
 to track when tests start, pause, resume and end. This allows
 the runtime to isolate global behaviour to only impact the
 specific test running.

The initial usecase of this is pubsub topics being isolated.