### PR TITLE
Update Patches to Support Go 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,16 @@ This branch is broken up into three main folders;
 - `overlay`; this folder contains brand-new Encore specific files which should be copied into the `src` path of a fresh Go Release
 - `patches`; this folder contains patch files to modify the existing Go source code
 - `go`; a submodule checkout of https://go.googlesource.com/go which we apply the above two folders against 
+
+## Creating Patches
+
+If patches do not apply due conflicts, or you need to make other changes to the Go runtime, apply the patches to get a
+base build, fix any conflicts or make your changes. Then from within the `go` folder, for each file run this command to
+copy the exact patch.
+
+```
+git diff --cached src/runtime/runtime2.go | pbcopy
+```
+
+Then create a new or update an existing `.diff` file in the patches folder. Once you've updated all the patches, re-run
+the `./apply_patches.bash` script again to check your changes work. 

--- a/apply_patch.bash
+++ b/apply_patch.bash
@@ -45,11 +45,7 @@ LAST_COMMIT_TIME=$(git log -1 --format=%cd)
 
 # Copy our overlay in and then apply the patches
 echo "🏗️  Applying Encore changes to the Go runtime..."
-  if [ -f ./VERSION ]; then
-    rm ./VERSION
-  fi
-
-  _ git apply --3way ../patches/*.diff
+  _ git apply --ignore-space-change --ignore-whitespace --3way ../patches/*.diff
   _ cp -p -P -v -R ../overlay/* ./
 echo
 

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"os"
 	"regexp"
+	"strings"
 
 	"go.encore.dev/go/builder"
 )
@@ -39,22 +40,43 @@ func main() {
 }
 
 func readBuiltVersion() {
-	bytes, err := ioutil.ReadFile("go/VERSION.cache")
-	if err != nil {
-		log.Fatalf("Unable to read built version: %+v", err)
+	str := ""
+	if isfile("go/VERSION") {
+		// If we're building from a release branch, we use this as the base
+		str = readfile("go/VERSION")
+		// Then we repeat the replace we do within the src/cmd/dist/build.go
+		str = strings.Replace(str, "go1.", "encore-go1.", 1)
+	} else {
+		// Otherwise we read the cache file which would be created by the build process
+		// if there was no VERSION file present
+		str = readfile("go/VERSION.cache")
 	}
 
-	str := string(bytes)
-
+	// With our patches there must always be an `encore-go1.xx` version in this string
+	// (there may be other bits, like "devel" or "beta" which we don't care about)
 	re, err := regexp.Compile("(encore-go[^ ]+)")
 	if err != nil {
 		log.Fatalf("Unable to compile regex: %+v", err)
 	}
-
 	version := re.FindString(str)
 	if version == "" {
-		log.Fatalf("Unable to extract version from `go/VERSION.cache` read: %s", str)
+		log.Fatalf("Unable to extract version, read: %s", str)
 	}
 
 	fmt.Println(version)
+}
+
+// isfile reports whether p names an existing file.
+func isfile(p string) bool {
+	fi, err := os.Stat(p)
+	return err == nil && fi.Mode().IsRegular()
+}
+
+// readfile returns the content of the named file.
+func readfile(file string) string {
+	data, err := ioutil.ReadFile(file)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+	return strings.TrimRight(string(data), " \t\r\n")
 }

--- a/patches/runtime_patch.diff
+++ b/patches/runtime_patch.diff
@@ -5,10 +5,10 @@ This patch modifies the Go runtime to add Encore specific tracking data to the G
 the and finish of a Go Routine executed due to a request made to your Encore app.
 
 diff --git a/src/runtime/proc.go b/src/runtime/proc.go
-index b997a467ba..c96f6c8476 100644
+index 3991a48b10..34daedcae0 100644
 --- a/src/runtime/proc.go
 +++ b/src/runtime/proc.go
-@@ -3454,6 +3454,11 @@ func goexit0(gp *g) {
+@@ -3473,6 +3473,11 @@ func goexit0(gp *g) {
  	_g_ := getg()
  	_p_ := _g_.m.p.ptr()
  
@@ -20,7 +20,7 @@ index b997a467ba..c96f6c8476 100644
  	casgstatus(gp, _Grunning, _Gdead)
  	gcController.addScannableStack(_p_, -int64(gp.stack.hi-gp.stack.lo))
  	if isSystemGoroutine(gp, false) {
-@@ -4110,6 +4115,11 @@ func newproc1(fn *funcval, callergp *g, callerpc uintptr) *g {
+@@ -4143,6 +4148,11 @@ func newproc1(fn *funcval, callergp *g, callerpc uintptr) *g {
  	gostartcallfn(&newg.sched, fn)
  	newg.gopc = callerpc
  	newg.ancestors = saveAncestors(callergp)
@@ -32,16 +32,16 @@ index b997a467ba..c96f6c8476 100644
  	newg.startpc = fn.fn
  	if isSystemGoroutine(newg, false) {
  		atomic.Xadd(&sched.ngsys, +1)
+
 diff --git a/src/runtime/runtime2.go b/src/runtime/runtime2.go
-index b40045e4a5..5b3763b6f1 100644
+index e1788223e7..93abd66585 100644
 --- a/src/runtime/runtime2.go
 +++ b/src/runtime/runtime2.go
-@@ -487,6 +487,8 @@ type g struct {
+@@ -488,6 +488,7 @@ type g struct {
+ 	labels         unsafe.Pointer // profiler labels
  	timer          *timer         // cached timer for time.Sleep
  	selectDone     uint32         // are we participating in a select and did someone win the race?
++	encore         unsafe.Pointer // encore-specific goroutine data
  
-+	encore unsafe.Pointer // encore-specific goroutine data
-+
- 	// Per-G GC state
- 
- 	// gcAssistBytes is this G's GC assist credit in terms of
+ 	// goroutineProfiled indicates the status of this goroutine's stack for the
+ 	// current in-progress goroutine profile

--- a/patches/version_patch.diff
+++ b/patches/version_patch.diff
@@ -10,25 +10,24 @@ to:
     `go version encore-go1.17.6 darwin/arm64`
 
 diff --git a/src/cmd/dist/build.go b/src/cmd/dist/build.go
-index d37c3f83ef..ea7f17eaa8 100644
+index 7c44c4a605..7c78480711 100644
 --- a/src/cmd/dist/build.go
 +++ b/src/cmd/dist/build.go
-@@ -341,6 +341,9 @@ func branchtag(branch string) (tag string, precise bool) {
- 		}
- 		break
- 	}
-+
-+	tag = "encore-" + tag
-+
- 	return
- }
-
-@@ -422,7 +425,7 @@ func findgoversion() string {
- 		if m == nil {
- 			fatalf("internal/goversion/goversion.go does not contain 'const Version = ...'")
- 		}
--		tag += fmt.Sprintf(" go1.%s-", m[1])
-+		tag += fmt.Sprintf(" encore-go1.%s-", m[1])
-
- 		tag += chomp(run(goroot, CheckExit, "git", "log", "-n", "1", "--format=format:%h %cd", "HEAD"))
- 	}
+@@ -362,7 +362,7 @@ func findgoversion() string {
+                    b = "builder " + hostType
+                }
+            }
+-           return b
++           return strings.Replace(b, "go1.", "encore-go1.", 1)
+        }
+    }
+ 
+@@ -393,7 +393,7 @@ func findgoversion() string {
+    if m == nil {
+        fatalf("internal/goversion/goversion.go does not contain 'const Version = ...'")
+    }
+-   version := fmt.Sprintf("devel go1.%s-", m[1])
++   version := fmt.Sprintf("devel encore-go1.%s-", m[1])
+    version += chomp(run(goroot, CheckExit, "git", "log", "-n", "1", "--format=format:%h %cd", "HEAD"))
+ 
+    // Cache version.


### PR DESCRIPTION
This commit updates our patches to mereg correctly with Go 1.19
and fixes a couple of small bugs.